### PR TITLE
repository service 리팩토링

### DIFF
--- a/src/main/kotlin/com/midasit/mcafe/domain/member/MemberRepository.kt
+++ b/src/main/kotlin/com/midasit/mcafe/domain/member/MemberRepository.kt
@@ -1,9 +1,14 @@
 package com.midasit.mcafe.domain.member
 
+import com.midasit.mcafe.infra.exception.CustomException
+import com.midasit.mcafe.infra.exception.ErrorMessage
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.repository.findByIdOrNull
+
+fun MemberRepository.getOrThrow(sn: Long): Member =
+    findByIdOrNull(sn) ?: throw CustomException(ErrorMessage.INVALID_LOGIN_REQUEST)
 
 interface MemberRepository : JpaRepository<Member, Long> {
-    fun findBySn(sn: Long): Member?
     fun findByUsername(username: String): Member?
     fun existsByUsername(username: String): Boolean
 }

--- a/src/main/kotlin/com/midasit/mcafe/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/midasit/mcafe/domain/member/MemberService.kt
@@ -9,6 +9,7 @@ import com.midasit.mcafe.infra.exception.CustomException
 import com.midasit.mcafe.infra.exception.ErrorMessage
 import com.midasit.mcafe.model.PasswordEncryptUtil
 import com.midasit.mcafe.model.Role
+import com.midasit.mcafe.model.validate
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -55,15 +56,14 @@ class MemberService(
     }
 
     fun findBySn(memberSn: Long): Member {
-        return memberRepository.findBySn(memberSn) ?: throw CustomException(ErrorMessage.INVALID_LOGIN_REQUEST)
+        return memberRepository.getOrThrow(memberSn)
     }
 
     private fun validateMember(request: MemberRequest.Signup): String {
         // 비밀번호 체크 검사
-        require(request.password == request.passwordCheck) { throw CustomException(ErrorMessage.INVALID_PASSWORD_CHECK) }
-
+        validate(ErrorMessage.INVALID_PASSWORD_CHECK) { request.password == request.passwordCheck }
         // 아이디 중복체크 검사
-        require(!memberRepository.existsByUsername(request.username)) { throw CustomException(ErrorMessage.DUPLICATE_ID) }
+        validate(ErrorMessage.DUPLICATE_ID) { !memberRepository.existsByUsername(request.username) }
 
         // u chef 인증 검사
         val valueOperations = redisTemplate.opsForValue()

--- a/src/main/kotlin/com/midasit/mcafe/domain/order/OrderRepository.kt
+++ b/src/main/kotlin/com/midasit/mcafe/domain/order/OrderRepository.kt
@@ -2,11 +2,22 @@ package com.midasit.mcafe.domain.order
 
 import com.midasit.mcafe.domain.member.Member
 import com.midasit.mcafe.domain.room.Room
+import com.midasit.mcafe.infra.exception.CustomException
+import com.midasit.mcafe.infra.exception.ErrorMessage
 import com.midasit.mcafe.model.OrderStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.repository.findByIdOrNull
+
+fun OrderRepository.getOrThrow(sn: Long): Order =
+    findByIdOrNull(sn) ?: throw CustomException(ErrorMessage.INVALID_REQUEST)
 
 interface OrderRepository : JpaRepository<Order, Long> {
-    fun findByMemberAndRoomAndMenuCodeAndStatus(member: Member, room: Room, menuCode: String, status: OrderStatus): List<Order>
+    fun findByMemberAndRoomAndMenuCodeAndStatus(
+        member: Member,
+        room: Room,
+        menuCode: String,
+        status: OrderStatus
+    ): List<Order>
+
     fun findByRoomAndStatus(room: Room, status: OrderStatus): List<Order>
-    fun findBySnAndStatus(orderSn: Long, status: OrderStatus): Order?
 }

--- a/src/main/kotlin/com/midasit/mcafe/domain/payment/PaymentService.kt
+++ b/src/main/kotlin/com/midasit/mcafe/domain/payment/PaymentService.kt
@@ -23,7 +23,7 @@ class PaymentService(
     @Transactional
     fun payOrder(memberSn: Long, roomSn: Long): PaymentResponse.PayOrder {
         val member = memberService.findBySn(memberSn)
-        val room = roomService.findByRoomSn(roomSn)
+        val room = roomService.findBySn(roomSn)
         roomService.checkMemberInRoom(member, room)
 
         val orderList = orderRepository.findByRoomAndStatus(room, OrderStatus.PENDING)
@@ -35,6 +35,8 @@ class PaymentService(
             it.updateOrderStatus(OrderStatus.DONE)
         }
 
-        return PaymentResponse.PayOrder(orderNo, orderList.map { OrderDto.of(it, uChefComponent.getMenuInfo(it.menuCode)) })
+        return PaymentResponse.PayOrder(
+            orderNo,
+            orderList.map { OrderDto.of(it, uChefComponent.getMenuInfo(it.menuCode)) })
     }
 }

--- a/src/main/kotlin/com/midasit/mcafe/domain/room/RoomRepository.kt
+++ b/src/main/kotlin/com/midasit/mcafe/domain/room/RoomRepository.kt
@@ -1,11 +1,15 @@
 package com.midasit.mcafe.domain.room
 
+import com.midasit.mcafe.infra.exception.CustomException
+import com.midasit.mcafe.infra.exception.ErrorMessage
 import com.midasit.mcafe.model.RoomStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.repository.findByIdOrNull
+
+fun RoomRepository.getOrThrow(sn: Long): Room =
+    findByIdOrNull(sn) ?: throw CustomException(ErrorMessage.INVALID_ROOM_INFO)
 
 interface RoomRepository : JpaRepository<Room, Long> {
     fun existsByName(name: String): Boolean
-    fun findByName(name: String): Room?
     fun findAllByStatusNot(roomStatus: RoomStatus): List<Room>
-    fun findBySn(sn: Long): Room?
 }

--- a/src/main/kotlin/com/midasit/mcafe/domain/roommember/RoomMemberRepository.kt
+++ b/src/main/kotlin/com/midasit/mcafe/domain/roommember/RoomMemberRepository.kt
@@ -4,7 +4,7 @@ import com.midasit.mcafe.domain.member.Member
 import com.midasit.mcafe.domain.room.Room
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface RoomMemberRepository: JpaRepository<RoomMember, Long> {
+interface RoomMemberRepository : JpaRepository<RoomMember, Long> {
     fun findByRoom(room: Room): List<RoomMember>
     fun findByMember(member: Member): List<RoomMember>
     fun existsByRoomAndMember(room: Room, member: Member): Boolean

--- a/src/main/kotlin/com/midasit/mcafe/model/Utils.kt
+++ b/src/main/kotlin/com/midasit/mcafe/model/Utils.kt
@@ -1,0 +1,8 @@
+package com.midasit.mcafe.model
+
+import com.midasit.mcafe.infra.exception.CustomException
+import com.midasit.mcafe.infra.exception.ErrorMessage
+
+fun validate(errorMessage: ErrorMessage = ErrorMessage.INVALID_REQUEST, block: () -> Boolean) {
+    if (block().not()) throw CustomException(errorMessage)
+}

--- a/src/test/kotlin/com/midasit/mcafe/domain/order/OrderControllerTest.kt
+++ b/src/test/kotlin/com/midasit/mcafe/domain/order/OrderControllerTest.kt
@@ -14,12 +14,12 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-class OrderControllerTest: ControllerTest() {
+class OrderControllerTest : ControllerTest() {
 
     private val orderService: OrderService = mockk()
 
     @InjectMocks
-    private val orderController =  OrderController(orderService)
+    private val orderController = OrderController(orderService)
 
     override fun getController(): Any {
         return orderController
@@ -34,14 +34,18 @@ class OrderControllerTest: ControllerTest() {
             val roomSn = 1L
             val request = OrderRequest.Create("menuCode", roomSn, listOf(1L, 2L))
             val menuInfoDto = MenuInfoDto("name", request.menuCode, 1000L, 1000L, arrayListOf())
-            val orderDto = OrderDto(1L,
+            val orderDto = OrderDto(
+                1L,
+                1L,
                 "nickname",
-                roomSn, menuInfoDto, 1L, request.optionList)
+                roomSn, menuInfoDto, 1L, request.optionList
+            )
             every { orderService.createOrder(any(), any()) } returns orderDto
             When("주문 생성 API를 호출하면") {
-                val result = perform(post("/order")
-                    .content(objectMapper.writeValueAsString(request))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                val result = perform(
+                    post("/order")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
                 ).andExpect {
                     status().isOk
                 }.andReturn()

--- a/src/test/kotlin/com/midasit/mcafe/domain/order/OrderServiceTest.kt
+++ b/src/test/kotlin/com/midasit/mcafe/domain/order/OrderServiceTest.kt
@@ -10,9 +10,6 @@ import com.midasit.mcafe.model.OrderStatus
 import com.midasit.mcafe.model.Role
 import com.midasit.mcafe.model.RoomStatus
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.extensions.spring.SpringExtension
-import io.kotest.extensions.spring.SpringTestExtension
-import io.kotest.extensions.spring.SpringTestLifecycleMode
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -44,7 +41,7 @@ class OrderServiceTest : BehaviorSpec({
         }
         ReflectionTestUtils.setField(room, "sn", roomSn)
         every { memberService.findBySn(any()) } returns member
-        every { roomService.findByRoomSn(any()) } returns room
+        every { roomService.findBySn(any()) } returns room
         every { orderRepository.save(any()) } returns order
         When("주문 등록하면") {
             val result = orderService.createOrder(memberSn, request)

--- a/src/test/kotlin/com/midasit/mcafe/domain/room/RoomServiceTest.kt
+++ b/src/test/kotlin/com/midasit/mcafe/domain/room/RoomServiceTest.kt
@@ -8,12 +8,11 @@ import com.midasit.mcafe.domain.roommember.RoomMember
 import com.midasit.mcafe.domain.roommember.RoomMemberRepository
 import com.midasit.mcafe.infra.component.UChefComponent
 import com.midasit.mcafe.infra.exception.CustomException
+import com.midasit.mcafe.infra.exception.ErrorMessage
 import com.midasit.mcafe.model.Role
 import com.midasit.mcafe.model.RoomStatus
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.extensions.spring.SpringTestExtension
-import io.kotest.extensions.spring.SpringTestLifecycleMode
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -40,7 +39,7 @@ class RoomServiceTest : BehaviorSpec({
     }
 
     given("방 정보가 주어졌을 때") {
-        val request = RoomRequest.Create("test",  RoomStatus.PUBLIC, "test")
+        val request = RoomRequest.Create("test", RoomStatus.PUBLIC, "test")
         val memberSn = 1L
         val member = Member(
             phone = "010-1234-1234",
@@ -66,7 +65,7 @@ class RoomServiceTest : BehaviorSpec({
         `when`("방을 생성할 때 이미 존재하는 방 이름이 있으면") {
             every { roomRepository.existsByName(any()) } answers { true }
             then("방이 생성되지 않는다.") {
-               shouldThrow<CustomException> {
+                shouldThrow<CustomException> {
                     roomService.createRoom(request, memberSn)
                 }
             }
@@ -82,7 +81,7 @@ class RoomServiceTest : BehaviorSpec({
         )
         every { roomRepository.findById(any()) } returns Optional.of(room)
         When("방 조회를 하면") {
-            val result = roomService.findByRoomSn(roomSn)
+            val result = roomService.findBySn(roomSn)
             then("방 정보가 반환된다.") {
                 result.name shouldBe room.name
             }
@@ -91,10 +90,10 @@ class RoomServiceTest : BehaviorSpec({
         every { roomRepository.findById(any()) } returns Optional.empty()
         When("방 조회를 하면") {
             val exception = shouldThrow<Exception> {
-                roomService.findByRoomSn(roomSn)
+                roomService.findBySn(roomSn)
             }
             then("에러가 반환된다.") {
-                exception.message shouldBe "존재하지 않는 방입니다."
+                exception.message shouldBe ErrorMessage.INVALID_ROOM_INFO.message
             }
         }
     }


### PR DESCRIPTION
기존 `require`는 `IlligalArgumentException`를 기본적으로 던지다 보니, CustomException을 이용할시에는 require구문 위에서 던져지는 형태가 되어, 해당 부분을 util로 빼서 validate라는 함수를 만들었으니, 이 부분 확인 한번 해주시면 될거같애요!

그리고 repository에 Spring에서 기본적으로 제공하는 jpa 확장함수가 있는데, 이 부분을 한번 더 확장하여, 값 하나를 반환하는 형태로 각 repository에 명시하였으니, 이 부분도 확인 한번 해주시면 되겠습니당