### PR TITLE
menu list와 menu info 정보를 캐싱합니다. last_update 값을 보고 캐시 데이터를 지워줍니다.

### DIFF
--- a/src/main/kotlin/com/midasit/mcafe/infra/component/rs/uchef/projectseq/UChefProjectSeqRs.kt
+++ b/src/main/kotlin/com/midasit/mcafe/infra/component/rs/uchef/projectseq/UChefProjectSeqRs.kt
@@ -14,5 +14,7 @@ class SearchResult(
 
 class MemberData(
     @JsonProperty("default_project_seq")
-    val defaultProjectSeq: Int
+    val defaultProjectSeq: Long,
+    @JsonProperty("last_update")
+    val lastUpdate: Long
 )


### PR DESCRIPTION
menuinfo 를 menuMap으로 캐싱하고 menuList를 menuList로 캐싱합니다.

캐싱 데이터는 getProjectSeq() 메서드가 호출 될 때 last_update가 높아졌을 경우 지워줍니다.

getProjectSeq() 는 모든 UChef api 호출할 때 호출 됩니다.